### PR TITLE
feat: overhaul kit recommendations, results UI and sticky header (v1.…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to KitCheck will be documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.1.0] - 2026-04-24
+
+### Added
+- Kit recommendation results now display each item on its own line with an "Optional" label where applicable
+- Info icon on the score tile with a hover popup explaining how the comfort score works
+- Sticky site header
+- Results widget accounts for sticky header offset
+
+### Changed
+- Recommendation logic overhauled for consistency across all body zones:
+  - Arm warmers and knee warmers now share the same required/optional temperature thresholds (required below ~14°C, optional up to ~17°C)
+  - Leg warmers correctly appear as an intermediate step between bib tights and knee warmers (8–11°C range)
+  - Long-sleeve jersey replaces the confusing "jersey or arm warmers" suggestion at 7–11°C
+  - Thermal socks removed as a standalone recommendation; feet zone now always shows regular cycling socks as base, with toe covers optional at 11–14°C
+  - Helmet now always shown in head zone results
+  - Fingerless gloves shown as "Fingerless gloves or no gloves" to reflect that some riders prefer bare hands
+  - "No gloves or fingerless gloves" shown at warm temperatures as an open choice
+- Guide page updated to match revised recommendation logic (temperature cards, FAQ answers and structured data)
+
+## [1.0.0] - 2026-04-24
+
+Initial public launch.
+
+### Added
+- Kit cost calculator with location search and unit selection
+- Guide page with usage instructions
+- Cookie consent banner with GA4 consent mode integration
+- Google Analytics (GA4) tracking
+- Cookie policy and privacy policy pages
+- Open Graph image for social sharing
+- Sitemap for SEO
+- Mobile-responsive layout across all pages
+
+### Fixed
+- Horizontal overflow on mobile
+- Responsive header buttons and calculator padding
+- Mobile layout improvements across calculator
+
+[Unreleased]: https://github.com/tieskuiper/kitcheck/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/tieskuiper/kitcheck/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/tieskuiper/kitcheck/releases/tag/v1.0.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kitcheck",
   "type": "module",
-  "version": "0.0.1",
+  "version": "1.1.0",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -6,7 +6,7 @@ import {
 } from '../lib/openmeteo'
 import {
   getKitRecommendation, scoreLabel,
-  type KitResult, type Intensity, type Level,
+  type KitResult, type Intensity, type Level, type ZoneItem,
 } from '../lib/kitLogic'
 
 // ── Tier / level accent colours (dynamic, must stay inline) ──────────────────
@@ -50,13 +50,13 @@ function Card({ children }: { children: ReactNode }) {
 // ── Location search ───────────────────────────────────────────────────────────
 function LocationSearch({
   query, setQuery, suggestions, onSearch, onAutoDetect, onSelectCity,
-  loading, locating, locationName, locationError, weatherLoaded, isLive, compact,
+  loading, locating, locationError, locationName, weatherLoaded, isLive,
 }: {
   query: string; setQuery: (v: string) => void
   suggestions: CityResult[]; onSearch: () => void
   onAutoDetect: () => void; onSelectCity: (c: CityResult) => void
-  loading: boolean; locating: boolean; locationName: string
-  locationError: string; weatherLoaded: boolean; isLive: boolean; compact?: boolean
+  loading: boolean; locating: boolean
+  locationError: string; locationName: string; weatherLoaded: boolean; isLive: boolean
 }) {
   return (
     <div>
@@ -131,12 +131,6 @@ function LocationSearch({
           <span className="text-[11px] text-text-light">— {isLive ? 'live conditions' : 'forecast'} loaded</span>
         </div>
       )}
-
-      {!weatherLoaded && !loading && !locationError && (
-        <div className={`text-center text-text-mid text-[13px] ${compact ? 'pt-[10px] pb-[2px]' : 'pt-4 pb-[6px]'}`}>
-          Search a city or use current location to load today's weather
-        </div>
-      )}
     </div>
   )
 }
@@ -188,8 +182,27 @@ function KitCard({ kitResult, score }: { kitResult: KitResult; score: ReturnType
         <div className="font-head text-[18px] sm:text-[22px] font-bold tracking-[-0.02em] mb-[6px]">
           {score.label} conditions
         </div>
-        <div className="text-[12px] opacity-80">
-          Score: <strong>{kitResult.score}</strong> / 110
+        <div className="flex items-center gap-2">
+          <div className="text-[12px] opacity-80">
+            Score: <strong>{kitResult.score}</strong> / 110
+          </div>
+          <div className="relative group">
+            <button
+              className="w-[18px] h-[18px] rounded-full border border-white/40 bg-white/15 flex items-center justify-center cursor-pointer hover:bg-white/25 transition-colors shrink-0"
+              aria-label="How the score is calculated"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none" className="w-[10px] h-[10px]">
+                <path d="M7 6.5v4M7 4.5v.5" stroke="white" strokeWidth="1.4" strokeLinecap="round" />
+              </svg>
+            </button>
+            <div className="absolute top-full left-0 mt-2 w-[260px] bg-white text-text rounded-xl p-3 shadow-[0_8px_32px_rgba(0,0,0,0.15)] opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-150 z-50 pointer-events-none">
+              <div className="font-head font-semibold mb-[6px] text-[11px] uppercase tracking-[0.06em] text-coral">How the score works</div>
+              <p className="text-[11px] leading-[1.6] m-0">
+                A comfort score based on how the conditions actually feel on the bike factoring in temperature, wind, your ride intensity, and how warm you naturally run.
+              </p>
+              <div className="mt-[6px] text-[10px] text-text-light">Lower = more kit needed · Higher = less kit needed</div>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -205,19 +218,17 @@ function KitCard({ kitResult, score }: { kitResult: KitResult; score: ReturnType
                   {CAT_LABELS[z.key]}
                 </span>
               </div>
-              <div className={`text-[12px] font-head font-semibold text-text leading-[1.4] ${z.key === 'torso' && z.layers && z.layers.length > 1 ? 'mb-[6px]' : ''
-                }`}>
-                {z.item}
-              </div>
-              {z.key === 'torso' && z.layers && z.layers.length > 1 && (
-                <ul className="p-0 m-0 list-none">
-                  {(z.layers as string[]).slice(1).map((layer, i) => (
-                    <li key={i} className="flex gap-[5px] items-start text-[11px] text-text-mid mb-[2px]">
-                      <span style={{ color: a }} className="text-[8px] mt-[3px]">●</span>{layer}
-                    </li>
-                  ))}
-                </ul>
-              )}
+              <ul className="p-0 m-0 list-none">
+                {(z.items as ZoneItem[]).map((zitem, i) => (
+                  <li key={i} className="flex gap-[6px] items-baseline text-[12px] font-head font-semibold text-text mb-[3px] last:mb-0">
+                    <span style={{ color: a }} className="text-[7px] shrink-0 relative top-[-1px]">●</span>
+                    <span>{zitem.name}</span>
+                    {zitem.optional && (
+                      <span className="font-normal text-[10px] text-text-light">Optional</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
             </div>
           )
         })}
@@ -282,6 +293,7 @@ export default function Calculator() {
 
   const searchTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const hourLabel = `${String(selectedHour).padStart(2, '0')}:00`
+  const isLive = selectedDay === 0 && selectedHour === new Date().getHours()
   const sl = useMemo(() => kitResult ? scoreLabel(kitResult.score) : null, [kitResult])
 
   function calculate(w: HourlySlice, wb: number, int: Intensity) {
@@ -395,27 +407,9 @@ export default function Calculator() {
                   suggestions={suggestions} onSearch={handleSearch}
                   onAutoDetect={geolocate} onSelectCity={selectCity}
                   loading={loading} locating={locating}
-                  locationName={locationName} locationError={locationError}
-                  weatherLoaded={weatherLoaded} isLive={selectedDay === 0 && selectedHour === new Date().getHours()} />
-                {weather && weatherLoaded && <WeatherChips weather={weather} unit={unit} />}
+                  locationError={locationError}
+                  locationName={locationName} weatherLoaded={weatherLoaded} isLive={isLive} />
               </Card>
-
-              {forecast && (
-                <Card>
-                  <div className="font-head text-[14px] font-bold mb-4">Day & departure time</div>
-                  <DayTabs days={DAY_LABELS} selected={selectedDay} onChange={handleDayChange} />
-                  <div className="mb-1 flex justify-between items-baseline">
-                    <Label text="Departure" />
-                    <span className="font-head text-[22px] font-bold text-coral">{hourLabel}</span>
-                  </div>
-                  <input type="range" min={0} max={23} value={selectedHour}
-                    aria-label="Departure time"
-                    onChange={e => handleHourChange(Number(e.target.value))} />
-                  <div className="flex justify-between mt-1 font-head text-[11px] text-text-light">
-                    {['00:00', '06:00', '12:00', '18:00', '23:00'].map(t => <span key={t}>{t}</span>)}
-                  </div>
-                </Card>
-              )}
 
               <Card>
                 <div className="font-head text-[14px] font-bold mb-4">Rider profile</div>
@@ -454,10 +448,28 @@ export default function Calculator() {
                   </div>
                 </div>
               </Card>
+
+              {forecast && (
+                <Card>
+                  <div className="font-head text-[14px] font-bold mb-4">Day & departure time</div>
+                  <DayTabs days={DAY_LABELS} selected={selectedDay} onChange={handleDayChange} />
+                  <div className="mb-1 flex justify-between items-baseline">
+                    <Label text="Departure" />
+                    <span className="font-head text-[22px] font-bold text-coral">{hourLabel}</span>
+                  </div>
+                  <input type="range" min={0} max={23} value={selectedHour}
+                    aria-label="Departure time"
+                    onChange={e => handleHourChange(Number(e.target.value))} />
+                  <div className="flex justify-between mt-1 font-head text-[11px] text-text-light">
+                    {['00:00', '06:00', '12:00', '18:00', '23:00'].map(t => <span key={t}>{t}</span>)}
+                  </div>
+                  {weather && <WeatherChips weather={weather} unit={unit} />}
+                </Card>
+              )}
             </div>
 
             {/* Right: output */}
-            <div className="md:sticky md:top-6 min-w-0">
+            <div className="md:sticky md:top-[88px] min-w-0">
               {kitResult && sl && weatherLoaded ? (
                 <KitCard kitResult={kitResult} score={sl} />
               ) : (

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -2,7 +2,7 @@
 const { pathname } = Astro.url;
 ---
 
-<header class="bg-bg border-b border-border">
+<header class="bg-bg border-b border-border sticky top-0 z-40">
   <div class="container">
     <div class="flex items-center justify-between h-16">
       <a

--- a/src/lib/kitLogic.ts
+++ b/src/lib/kitLogic.ts
@@ -7,11 +7,17 @@
 export type Intensity = 'easy' | 'moderate' | 'hard' | 'race'
 export type Level     = 'heavy' | 'medium' | 'light' | 'none'
 
+export interface ZoneItem {
+  name:      string
+  optional?: boolean
+}
+
 export interface ZoneRecommendation {
   item:    string
   detail:  string | null
   level:   Level
   icon:    string
+  items:   ZoneItem[]
   layers?: string[]
 }
 
@@ -68,29 +74,35 @@ export function getKitRecommendation(input: RiderInput): KitResult {
   }
 }
 
+// Score → approx apparent temp: 20≈0°C  35≈6°C  50≈11°C  62≈14°C  74≈17°C  86≈20°C  90≈22°C
+// "Optional" band for all zones: score 62–74 (≈14–17°C). Required below 62, gone above 74.
+
 function getHead(score: number): ZoneRecommendation {
-  if (score < 20) return { item: 'Thermal skull cap + helmet',  detail: 'Full ear coverage essential. Wear under helmet.', level: 'heavy',  icon: '🧢' }
-  if (score < 38) return { item: 'Cycling cap under helmet',    detail: 'Ear and forehead coverage recommended.',          level: 'medium', icon: '🧢' }
-  if (score < 55) return { item: 'Light cap or nothing',        detail: 'A thin summer cap gives some wind protection.',   level: 'light',  icon: '🧢' }
-  return                 { item: 'Helmet only',                 detail: 'No head coverage needed.',                        level: 'none',   icon: '⛑️' }
+  if (score < 20) return { item: 'Thermal skull cap', items: [{ name: 'Thermal skull cap' }, { name: 'Helmet' }],  detail: 'Full ear coverage essential. Wear under helmet.', level: 'heavy',  icon: '🧢' }
+  if (score < 40) return { item: 'Cycling cap',       items: [{ name: 'Cycling cap' }, { name: 'Helmet' }],        detail: 'Ear and forehead coverage recommended.',          level: 'medium', icon: '🧢' }
+  if (score < 62) return { item: 'Helmet',       items: [{ name: 'Helmet' }, { name: 'Light cap', optional: true }], detail: 'A thin summer cap under your helmet gives some wind protection.',   level: 'light',  icon: '🧢' }
+  return                 { item: 'Helmet',       items: [{ name: 'Helmet' }],                                       detail: 'No head covering needed.',                        level: 'none',   icon: '⛑️' }
 }
 
 function getTorso(score: number, isRainy: boolean, isWindy: boolean): ZoneRecommendation {
-  let layers: string[] = []
+  let items: ZoneItem[] = []
   let level: Level = 'none'
-  if      (score < 20) { layers = ['Thermal long-sleeve base layer', 'Winter jersey', 'Insulated jacket']; level = 'heavy'  }
-  else if (score < 35) { layers = ['Long-sleeve base layer', 'Winter jersey or softshell'];                level = 'heavy'  }
-  else if (score < 50) { layers = ['Short-sleeve base layer', 'Long-sleeve jersey or arm warmers'];        level = 'medium' }
-  else if (score < 65) { layers = ['Summer jersey', 'Arm warmers (removable)'];                            level = 'medium' }
-  else if (score < 80) { layers = ['Summer jersey'];                                                        level = 'light'  }
-  else                 { layers = ['Lightweight summer jersey'];                                            level = 'none'   }
-  if (isRainy)                  { layers.push('Rain jacket (waterproof)'); level = 'heavy' }
-  else if (isWindy && score < 70) layers.push('Wind gilet')
+  if      (score < 20) { items = [{ name: 'Thermal long-sleeve base layer' }, { name: 'Winter jersey' }, { name: 'Insulated jacket' }]; level = 'heavy'  }
+  else if (score < 35) { items = [{ name: 'Thermal base layer' }, { name: 'Winter jersey or softshell' }];                              level = 'heavy'  }
+  else if (score < 50) { items = [{ name: 'Long-sleeve jersey' }, { name: 'Base layer', optional: true }];                              level = 'medium' }
+  else if (score < 62) { items = [{ name: 'Jersey' }, { name: 'Arm warmers' }];                                                         level = 'medium' }
+  else if (score < 74) { items = [{ name: 'Jersey' }, { name: 'Arm warmers', optional: true }];                                         level = 'light'  }
+  else if (score < 86) { items = [{ name: 'Summer jersey' }];                                                                           level = 'light'  }
+  else                 { items = [{ name: 'Lightweight summer jersey' }];                                                                level = 'none'   }
+  if (isRainy)                    { items.push({ name: 'Rain jacket (waterproof)' }); level = 'heavy' }
+  else if (isWindy && score < 74)   items.push({ name: 'Wind gilet', optional: true })
   return {
-    item:   layers[0],
-    layers,
+    item:   items[0].name,
+    items,
+    layers: items.map(i => i.name),
     detail: isRainy  ? 'Rain is likely — a waterproof outer layer is essential.'
            : isWindy ? 'Wind is significant — a gilet or windproof layer adds comfort.'
+           : score < 50 ? 'A base layer underneath adds warmth and wicks sweat — recommended when it\'s this cold.'
            : null,
     level,
     icon: '🚴',
@@ -98,27 +110,30 @@ function getTorso(score: number, isRainy: boolean, isWindy: boolean): ZoneRecomm
 }
 
 function getHands(score: number, isRainy: boolean): ZoneRecommendation {
-  if (isRainy || score < 20) return { item: 'Waterproof winter gloves',              detail: isRainy ? 'Rain + cold hands = miserable ride.' : 'Maximum insulation needed.', level: 'heavy',  icon: '🧤' }
-  if (score < 35)            return { item: 'Thermal winter gloves',                 detail: 'Insulated gloves. Hands lose heat fast at pace.',                              level: 'heavy',  icon: '🧤' }
-  if (score < 50)            return { item: 'Light cycling gloves',                  detail: 'Wind protection needed. Fingerless not enough.',                               level: 'medium', icon: '🧤' }
-  if (score < 65)            return { item: 'Fingerless or thin full-finger gloves', detail: 'Fingerless works, but carry a spare pair.',                                    level: 'light',  icon: '🧤' }
-  return                            { item: 'No gloves needed',                      detail: 'Optionally fingerless for grip.',                                              level: 'none',   icon: '✋' }
+  if (isRainy || score < 20) return { item: 'Waterproof winter gloves', items: [{ name: 'Waterproof winter gloves' }],                                              detail: isRainy ? 'Rain + cold hands = miserable ride.' : 'Maximum insulation needed.',  level: 'heavy',  icon: '🧤' }
+  if (score < 35)            return { item: 'Thermal winter gloves',    items: [{ name: 'Thermal winter gloves' }],                                                  detail: 'Insulated gloves. Hands lose heat fast at pace.',                               level: 'heavy',  icon: '🧤' }
+  if (score < 50)            return { item: 'Light cycling gloves',     items: [{ name: 'Light cycling gloves' }],                                                   detail: 'Wind protection needed. Fingerless gloves won\'t cut it.',                      level: 'medium', icon: '🧤' }
+  if (score < 62)            return { item: 'Fingerless gloves',        items: [{ name: 'Fingerless gloves or no gloves' }, { name: 'Thin full-finger gloves', optional: true }], detail: 'Fingerless work well — full-finger if you run cold, bare hands if you prefer.',  level: 'light',  icon: '🧤' }
+  if (score < 74)            return { item: 'Fingerless gloves',        items: [{ name: 'Fingerless gloves or no gloves', optional: true }],                                detail: 'Gloves optional — useful on descents or into a headwind.',                       level: 'light',  icon: '🧤' }
+  return                            { item: 'No gloves',                items: [{ name: 'No gloves or fingerless gloves' }],                                                 detail: 'Warm enough for bare hands — fingerless optional for grip or comfort.',   level: 'none',   icon: '✋' }
 }
 
 function getLegs(score: number): ZoneRecommendation {
-  if (score < 25) return { item: 'Thermal bib tights + leg warmers',    detail: 'Double insulation. Fleece-lined tights recommended.', level: 'heavy',  icon: '🦵' }
-  if (score < 42) return { item: 'Bib tights',                          detail: 'Full leg coverage. Winter weight.',                   level: 'heavy',  icon: '🦵' }
-  if (score < 58) return { item: 'Bib shorts + knee warmers',           detail: 'Knee warmers easy to roll down if you warm up.',      level: 'medium', icon: '🦵' }
-  if (score < 68) return { item: 'Bib shorts + leg warmers (optional)', detail: 'You might not need them, but pack just in case.',     level: 'light',  icon: '🦵' }
-  return                 { item: 'Bib shorts',                          detail: 'Full summer shorts. Enjoy.',                          level: 'none',   icon: '🩳' }
+  // Leg warmers (colder) → knee warmers (milder) — not the other way around
+  if (score < 22) return { item: 'Thermal bib tights', items: [{ name: 'Thermal bib tights' }, { name: 'Leg warmers' }],             detail: 'Double insulation. Fleece-lined tights recommended.',                              level: 'heavy',  icon: '🦵' }
+  if (score < 40) return { item: 'Bib tights',         items: [{ name: 'Bib tights' }],                                              detail: 'Full leg coverage. Winter-weight tights.',                                         level: 'heavy',  icon: '🦵' }
+  if (score < 52) return { item: 'Bib shorts',         items: [{ name: 'Bib shorts' }, { name: 'Leg warmers' }],                     detail: 'Full leg coverage — legs need time to warm up at these temperatures.',              level: 'medium', icon: '🦵' }
+  if (score < 62) return { item: 'Bib shorts',         items: [{ name: 'Bib shorts' }, { name: 'Knee warmers' }],                    detail: 'Knees chill quickly even when your legs are working hard. Easy to pocket mid-ride.', level: 'medium', icon: '🦵' }
+  if (score < 74) return { item: 'Bib shorts',         items: [{ name: 'Bib shorts' }, { name: 'Knee warmers', optional: true }],    detail: 'Legs should stay warm enough, but knee warmers help on cold starts or descents.',   level: 'light',  icon: '🦵' }
+  return                 { item: 'Bib shorts',         items: [{ name: 'Bib shorts' }],                                              detail: 'Full summer shorts. Enjoy.',                                                       level: 'none',   icon: '🩳' }
 }
 
 function getFeet(score: number, isRainy: boolean): ZoneRecommendation {
-  if (isRainy || score < 20) return { item: 'Waterproof overshoes + thermal socks', detail: isRainy ? 'Wet feet ruin rides. Full neoprene overshoes.' : 'Maximum insulation needed.', level: 'heavy',  icon: '👟' }
-  if (score < 35)            return { item: 'Thermal overshoes + thermal socks',    detail: 'Wind and cold protection. Fleece-lined overshoes.',                                       level: 'heavy',  icon: '👟' }
-  if (score < 50)            return { item: 'Light overshoes or toe covers',        detail: 'Toe covers take the edge off, especially descending.',                                    level: 'medium', icon: '👟' }
-  if (score < 65)            return { item: 'Thermal cycling socks',                detail: 'Thicker socks only. No overshoes needed.',                                                level: 'light',  icon: '🧦' }
-  return                            { item: 'Regular cycling socks',                detail: 'Normal summer socks.',                                                                    level: 'none',   icon: '🧦' }
+  if (isRainy || score < 20) return { item: 'Waterproof overshoes', items: [{ name: 'Waterproof overshoes' }, { name: 'Thermal socks' }], detail: isRainy ? 'Wet feet ruin rides. Full neoprene overshoes.' : 'Maximum insulation needed.',     level: 'heavy',  icon: '👟' }
+  if (score < 35)            return { item: 'Thermal overshoes',    items: [{ name: 'Thermal overshoes' }, { name: 'Thermal socks' }],    detail: 'Wind and cold protection essential. Fleece-lined overshoes.',                               level: 'heavy',  icon: '👟' }
+  if (score < 50)            return { item: 'Light overshoes',      items: [{ name: 'Light overshoes or toe covers' }],                   detail: 'Feet cool fast at speed — wind protection makes a noticeable difference.',                   level: 'medium', icon: '👟' }
+  if (score < 62)            return { item: 'Regular socks',        items: [{ name: 'Regular cycling socks' }, { name: 'Toe covers', optional: true }],  detail: 'Toe covers take the edge off the windchill, especially on longer descents.',  level: 'light',  icon: '👟' }
+  return                            { item: 'Regular socks',        items: [{ name: 'Regular cycling socks' }],                                               detail: 'Normal summer socks.',                                                       level: 'none',   icon: '🧦' }
 }
 
 export function scoreLabel(score: number): { label: string; color: string } {

--- a/src/pages/guide.astro
+++ b/src/pages/guide.astro
@@ -30,7 +30,7 @@ const faqSchema = {
           name: "What should I wear cycling at 10°C?",
           acceptedAnswer: {
             "@type": "Answer",
-            text: "At 10°C most cyclists need a long-sleeve jersey with arm warmers, bib tights or knee warmers, light gloves, and toe covers. At moderate-to-hard intensity you may only need knee warmers rather than full tights. kitcheck.cc adjusts the recommendation automatically based on your effort level.",
+            text: "At 10°C most cyclists need a long-sleeve jersey (with a base layer underneath if you run cold), bib shorts with leg warmers, light cycling gloves, and toe covers or light overshoes. Arm warmers belong with a short-sleeve jersey at warmer temperatures — at 10°C a long-sleeve jersey is the right outer layer. kitcheck.cc adjusts the recommendation automatically based on your effort level.",
           },
         },
         {
@@ -78,7 +78,7 @@ const faqSchema = {
           name: "Should I wear bib shorts or bib tights?",
           acceptedAnswer: {
             "@type": "Answer",
-            text: "The crossover point for most cyclists is around 12–14°C: below that, knee warmers or thermal bib tights keep muscles warmer and reduce injury risk. Above it, bib shorts with optional knee warmers give more flexibility. Wind and rain lower the effective threshold. kitcheck.cc recommends the right lower-body option based on your local conditions.",
+            text: "Bib tights below about 8°C, then bib shorts with leg warmers from 8–11°C, and bib shorts with knee warmers for the 11–14°C range. Above 14°C bib shorts alone are usually fine, with knee warmers optional if it feels fresh. Wind and rain both push those thresholds up. kitcheck.cc picks the right option based on your actual conditions.",
           },
         },
       ],
@@ -210,10 +210,9 @@ const faqSchema = {
           </p>
           <ul class="space-y-1.5 text-sm text-text-mid">
             <li>Long-sleeve jersey</li>
-            <li>Wind or rain gilet</li>
-            <li>Bib tights or knee warmers</li>
-            <li>Light gloves</li>
-            <li>Toe covers</li>
+            <li>Bib tights (below 8°C) or bib shorts + leg warmers</li>
+            <li>Light cycling gloves</li>
+            <li>Toe covers or light overshoes</li>
           </ul>
         </div>
 
@@ -231,11 +230,10 @@ const faqSchema = {
             Mild
           </p>
           <ul class="space-y-1.5 text-sm text-text-mid">
-            <li>Short-sleeve jersey</li>
-            <li>Arm warmers (rollable)</li>
-            <li>Bib shorts</li>
-            <li>Thin gloves optional</li>
-            <li>Gilet in pocket</li>
+            <li>Jersey + arm warmers</li>
+            <li>Bib shorts + knee warmers</li>
+            <li>Fingerless gloves or no gloves</li>
+            <li>Toe covers optional</li>
           </ul>
         </div>
 
@@ -408,11 +406,12 @@ const faqSchema = {
             >
           </summary>
           <p class="mt-3 text-sm text-text-mid leading-relaxed pr-8">
-            Long-sleeve jersey with arm warmers, bib tights or knee warmers,
-            light gloves and toe covers. If you're riding at a decent pace, knee
-            warmers often do the job instead of full tights. This is the range
-            where your intensity makes the biggest difference to what you'll
-            actually need.
+            Long-sleeve jersey (add a base layer if you run cold), bib shorts
+            with leg warmers, light cycling gloves, and toe covers or light
+            overshoes. At 10°C arm warmers belong with a short-sleeve jersey at
+            warmer temperatures — a long-sleeve jersey is the right call here.
+            This is the range where intensity makes the biggest difference to
+            what you'll actually need.
           </p>
         </details>
 
@@ -567,11 +566,12 @@ const faqSchema = {
             >
           </summary>
           <p class="mt-3 text-sm text-text-mid leading-relaxed pr-8">
-            Most people switch somewhere around 12 to 14°C. Below that your legs
-            get cold fast, especially on longer rides. Above it bib shorts are
-            usually fine, maybe with knee warmers if it feels fresh. Wind and
-            rain both push that threshold up. kitcheck.cc picks the right option
-            based on your conditions.
+            Bib tights below about 8°C, then bib shorts with leg warmers from
+            8–11°C, and bib shorts with knee warmers for the 11–14°C range.
+            Above 14°C bib shorts alone are usually fine — knee warmers still
+            help on cold starts or long descents. Wind and rain push those
+            thresholds up. kitcheck.cc picks the right option based on your
+            conditions.
           </p>
         </details>
       </div>


### PR DESCRIPTION
…1.0)

- Each kit item now displayed on its own line with Optional label
- Recommendation logic aligned across all zones: arm/knee warmers share the same required (<14°C) and optional (14–17°C) thresholds
- Leg warmers correctly precede knee warmers in the cold progression
- Long-sleeve jersey replaces the jersey+arm warmers conflation at 7–11°C
- Feet always show regular cycling socks as base; thermal socks removed from warm range; toe covers optional at 11–14°C
- Helmet always shown in head zone; fingerless gloves shown as or/no gloves
- Score tile gets hover info popup (no formula exposed)
- Sticky site header; results widget top offset updated accordingly
- Guide page (cards, FAQs, structured data) updated to match new logic